### PR TITLE
chore(hooks): fix regex that did not allow for breaking changes

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -3,7 +3,7 @@
 MSG=$(<"$1")
 
 # Example: chore(dependencies): Update dependencies #123
-echo "$MSG" | grep -Eq '^(build|chore|ci|docs|feat|fix|refactor|revert|style|test)(\([a-zA-Z0-9_-]+\))?: .+( #[0-9]+)?$' \
+echo "$MSG" | grep -Eq '^(build|chore|ci|docs|feat|fix|refactor|revert|style|test)(\([a-zA-Z0-9_-]+\))?!?: .+( #[0-9]+)?$' \
   || {
     echo "Your commit message does not conform to the project standard!"
     echo "Your commit message was: '$MSG'"


### PR DESCRIPTION
The regex did not account for an optional "!", which signifies a breaking change.

See: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope-and--to-draw-attention-to-breaking-change