### PR TITLE
ci: force renovate to use 'chore'

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    ":rebaseStalePrs"
+    ":rebaseStalePrs",
+    ":semanticCommitTypeAll(chore)"
   ],
   "schedule" : [
     "* 23,0-4 * * *"


### PR DESCRIPTION
Renovate updates have somethings the `fix` scope which is not desired behavior. This should force it to always be `chore`.