### PR TITLE
fix: error message on overview uses the entire table width #444

### DIFF
--- a/frontend/src/app/features/member/overview/member-overview.component.html
+++ b/frontend/src/app/features/member/overview/member-overview.component.html
@@ -130,7 +130,7 @@
     ></tr>
 
     <tr *matNoDataRow data-testid="no-results-row">
-      <td colspan="4">
+      <td colspan="5">
         {{ 'TABLE.NO_SEARCH_RESULT' | scopedTranslation : {model: 'MODEL_NAME' | scopedTranslation ,searchValue: searchControl.value} }}
       </td>
     </tr>


### PR DESCRIPTION
I thought the would be more to this than changing a single number :) 

<img width="1986" height="291" alt="image" src="https://github.com/user-attachments/assets/d6e46ca7-0f2d-4396-90cc-ce7c8a338780" />
