### PR TITLE
ci: make renovate wait 3 days and automerge patches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,8 +12,17 @@
     "* 23,0-4 * * *"
   ],
   "automergeType": "pr",
+  "prCreation": "not-pending",
   "timezone": "Europe/Zurich",
+  "platformAutomerge": true,
+  "minimumReleaseAge": "3 days",
   "packageRules": [
+    {
+      "description": "Automerge patch updates after they are 3 days old",
+      "matchUpdateTypes": ["patch"],
+      "automerge": true,
+      "automergeType": "pr"
+    },
     {
       "groupName": "All Angular packages",
       "matchPackageNames": [


### PR DESCRIPTION
This PR _should_ accomplish two things:
- PRs should only be created 3 days after the update was release, hopefully mitigating some supply chain attacks
- Automerging all `patch` type updates