### PR TITLE
fix: submit and copy button wrongly invalidates form #472

### DIFF
--- a/frontend/cypress/e2e/add-leadership-experience.cy.ts
+++ b/frontend/cypress/e2e/add-leadership-experience.cy.ts
@@ -20,7 +20,7 @@ describe('Add leadershipExperience modal', () => {
       .should('include.text', 'Führungserfahrung hinzufügen');
   });
 
-  it.only('should create leadershipExperience', () => {
+  it('should create leadershipExperience', () => {
     openLeadershipExModal();
 
     formPage.submitButtonShouldBe('disabled');

--- a/frontend/src/app/features/certificates/add-certificate/add-certificate.component.ts
+++ b/frontend/src/app/features/certificates/add-certificate/add-certificate.component.ts
@@ -64,7 +64,7 @@ export class AddCertificateComponent extends StrictlyTypedDialog<CertificateMode
     member: [null as MemberModel | null],
     certificateType: [null as CertificateTypeModel | null,
       [Validators.required,
-        isValueInListSignal(this.certificateTypeOptions)]],
+        isValueInListSignal(this.certificateTypeOptions, (a, b) => a.id === b.id)]],
     completedAt: [null as Date | null,
       Validators.required],
     validUntil: [null as Date | null],

--- a/frontend/src/app/features/leadership-experiences/add-leadership-experience/add-leadership-experience.component.ts
+++ b/frontend/src/app/features/leadership-experiences/add-leadership-experience/add-leadership-experience.component.ts
@@ -50,7 +50,7 @@ export class AddLeadershipExperienceComponent extends StrictlyTypedDialog<Leader
     member: [null as MemberModel | null],
     leadershipExperienceType: [null as LeadershipExperienceTypeModel | null,
       [Validators.required,
-        isValueInListSignal(this.leadershipExperienceTypeOptions)]],
+        isValueInListSignal(this.leadershipExperienceTypeOptions, (a, b) => a.id === b.id)]],
     comment: ['' as string | null]
   });
 

--- a/frontend/src/app/features/member/form/member-form.component.ts
+++ b/frontend/src/app/features/member/form/member-form.component.ts
@@ -78,9 +78,9 @@ export class MemberFormComponent implements OnInit {
     dateOfHire: [''],
     employmentState: [null,
       [Validators.required,
-        isValueInList(this.employmentStateOptions)]],
+        isValueInList(this.employmentStateOptions, (a, b) => a == b)]],
     organisationUnit: [null,
-      isValueInListSignal(this.organisationUnitsOptions)]
+      isValueInListSignal(this.organisationUnitsOptions, (a, b) => a.id === b.id)]
   });
 
   protected employmentStateControlSignal = toSignal(this.memberForm.get('employmentState')!.valueChanges.pipe(map((value) => value ?? '')), {

--- a/frontend/src/app/shared/form/form-validators.spec.ts
+++ b/frontend/src/app/shared/form/form-validators.spec.ts
@@ -78,6 +78,8 @@ describe('isValueInList', () => {
     'Banana',
     'Cherry'];
 
+  const comparator = (a, b) => a === b;
+
   it('should return null if value is empty', () => {
     const control = new FormControl('');
     expect(isValueInList(options)(control))
@@ -95,6 +97,24 @@ describe('isValueInList', () => {
     expect(isValueInList(options)(control))
       .toEqual({ invalid_entry: true });
   });
+
+  it('should return null if value is empty with comparator', () => {
+    const control = new FormControl('');
+    expect(isValueInList(options, comparator)(control))
+      .toBeNull();
+  });
+
+  it('should return null if value is allowed with comparator', () => {
+    const control = new FormControl('Banana');
+    expect(isValueInList(options, comparator)(control))
+      .toBeNull();
+  });
+
+  it('should return invalid_entry if value is not allowed with comparator', () => {
+    const control = new FormControl('Orange');
+    expect(isValueInList(options, comparator)(control))
+      .toEqual({ invalid_entry: true });
+  });
 });
 
 
@@ -102,6 +122,8 @@ describe('isValueInListSignal', () => {
   const optionsSignal = signal(['Red',
     'Green',
     'Blue']);
+
+  const comparator = (a, b) => a === b;
 
   it('should return null if value is empty', () => {
     const control = new FormControl('');
@@ -118,6 +140,24 @@ describe('isValueInListSignal', () => {
   it('should return invalid_entry if value is not in the signal list', () => {
     const control = new FormControl('Yellow');
     expect(isValueInListSignal(optionsSignal)(control))
+      .toEqual({ invalid_entry: true });
+  });
+
+  it('should return null if value is empty with comparator', () => {
+    const control = new FormControl('');
+    expect(isValueInListSignal(optionsSignal, comparator)(control))
+      .toBeNull();
+  });
+
+  it('should return null if value is in the signal list with comparator', () => {
+    const control = new FormControl('Green');
+    expect(isValueInListSignal(optionsSignal, comparator)(control))
+      .toBeNull();
+  });
+
+  it('should return invalid_entry if value is not in the signal list with comparator', () => {
+    const control = new FormControl('Yellow');
+    expect(isValueInListSignal(optionsSignal, comparator)(control))
       .toEqual({ invalid_entry: true });
   });
 

--- a/frontend/src/app/shared/form/form-validators.ts
+++ b/frontend/src/app/shared/form/form-validators.ts
@@ -46,7 +46,7 @@ export function isDateInPast(): ValidatorFn {
   };
 }
 
-export function isValueInList<T>(validOptions: T[]): ValidatorFn {
+export function isValueInList<T>(validOptions: T[], comparator?: (a: T, b: T) => boolean): ValidatorFn {
   return (control: AbstractControl): ValidationErrors | null => {
     const value: any = control.value;
 
@@ -54,22 +54,25 @@ export function isValueInList<T>(validOptions: T[]): ValidatorFn {
       return null;
     }
 
-    const isValidOption: boolean = validOptions.includes(value);
+    const isValidOption: boolean = comparator
+      ? validOptions.some((option) => comparator(option, value))
+      : validOptions.includes(value);
 
     return isValidOption ? null : { invalid_entry: true };
   };
 }
 
-export function isValueInListSignal<T>(validOptionsSignal: Signal<T[]>): ValidatorFn {
+export function isValueInListSignal<T>(validOptionsSignal: Signal<T[]>, comparator?: (a: T, b: T) => boolean): ValidatorFn {
   return (control: AbstractControl): ValidationErrors | null => {
     const value: any = control.value;
     const validOptions: T[] = validOptionsSignal();
-
     if (!value) {
       return null;
     }
 
-    const isValidOption: boolean = validOptions.includes(value);
+    const isValidOption: boolean = comparator
+      ? validOptions.some((option) => comparator(option, value))
+      : validOptions.includes(value);
 
     return isValidOption ? null : { invalid_entry: true };
   };

--- a/frontend/src/app/shared/form/form-validators.ts
+++ b/frontend/src/app/shared/form/form-validators.ts
@@ -46,7 +46,7 @@ export function isDateInPast(): ValidatorFn {
   };
 }
 
-export function isValueInList<T>(validOptions: T[], comparator?: (a: T, b: T) => boolean): ValidatorFn {
+export function isValueInList<T>(validOptions: T[], comparator: (a: T, b: T) => boolean = (a, b) => a === b): ValidatorFn {
   return (control: AbstractControl): ValidationErrors | null => {
     const value: any = control.value;
 
@@ -54,15 +54,13 @@ export function isValueInList<T>(validOptions: T[], comparator?: (a: T, b: T) =>
       return null;
     }
 
-    const isValidOption: boolean = comparator
-      ? validOptions.some((option) => comparator(option, value))
-      : validOptions.includes(value);
+    const isValidOption: boolean = validOptions.some((option) => comparator(option, value));
 
     return isValidOption ? null : { invalid_entry: true };
   };
 }
 
-export function isValueInListSignal<T>(validOptionsSignal: Signal<T[]>, comparator?: (a: T, b: T) => boolean): ValidatorFn {
+export function isValueInListSignal<T>(validOptionsSignal: Signal<T[]>, comparator: (a: T, b: T) => boolean = (a, b) => a === b): ValidatorFn {
   return (control: AbstractControl): ValidationErrors | null => {
     const value: any = control.value;
     const validOptions: T[] = validOptionsSignal();
@@ -70,9 +68,7 @@ export function isValueInListSignal<T>(validOptionsSignal: Signal<T[]>, comparat
       return null;
     }
 
-    const isValidOption: boolean = comparator
-      ? validOptions.some((option) => comparator(option, value))
-      : validOptions.includes(value);
+    const isValidOption: boolean = validOptions.some((option) => comparator(option, value));
 
     return isValidOption ? null : { invalid_entry: true };
   };

--- a/frontend/src/app/shared/modal/base-modal.component.ts
+++ b/frontend/src/app/shared/modal/base-modal.component.ts
@@ -1,5 +1,5 @@
 import { Component, input, output } from '@angular/core';
-import { MatDialogActions, MatDialogClose, MatDialogContent, MatDialogTitle } from '@angular/material/dialog';
+import { MatDialogActions, MatDialogContent, MatDialogTitle } from '@angular/material/dialog';
 import { MatDivider } from '@angular/material/divider';
 import { MatIconButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
@@ -17,7 +17,6 @@ import { FormGroup } from '@angular/forms';
     MatDialogContent,
     MatDialogActions,
     MatIcon,
-    MatDialogClose,
     MatIconButton,
     ScopedTranslationPipe,
     BaseFormActionsComponent


### PR DESCRIPTION
TLDR: opening an new modal, changes the instances which means instance validation no longer seems to work. Adding an optional `comparatorFunction` fixed this.